### PR TITLE
accept multiple arguments in logging methods

### DIFF
--- a/lib/nlogger.js
+++ b/lib/nlogger.js
@@ -87,6 +87,13 @@ function getMessage(msg) {
 	}
 }
 
+function getMessages(args) {
+	var formatted = Array.prototype.map.call(args, function (arg){ 
+		return getMessage(arg); 
+	});
+	return formatted.join (" ");
+}
+
 try {
 	var file = fs.readFileSync('./nlogger.json', 'binary'),
 		config = JSON.parse(file);
@@ -117,15 +124,17 @@ exports.logger = function(module) {
 		var levelStr = level.toUpperCase();
 		if (levelStr.length == 4) levelStr += ' ';
 		if (useColor) {
-			logger[level] = function(msg) {
+			logger[level] = function() {
 				if (methods[level].priority >= priority) {
-					sys.puts('\x1B[' + methods[level].color + 'm' + getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + getMessage(msg) + '\x1B[0m');
+					msg = getMessages(arguments);
+					sys.puts('\x1B[' + methods[level].color + 'm' + getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + msg + '\x1B[0m');
 				}
 			};
 		} else {
-			logger[level] = function(msg) {
+			logger[level] = function() {
 				if (methods[level].priority >= priority) {
-					sys.puts(getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + getMessage(msg));
+					msg = getMessages(arguments);
+					sys.puts(getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + msg);
 				}
 			};
 		}


### PR DESCRIPTION
makes logger behave a little bit like more console.log: it calls getMessage on all arguments and concatenates them with spaces. 

especially useful to mix strings and objects, eg: 

<pre>
 logger.debug ('config:', config);
</pre>
