### PR TITLE
Line number bug when used on node.js for Windows

### DIFF
--- a/lib/nlogger.js
+++ b/lib/nlogger.js
@@ -56,7 +56,7 @@ function getDate() {
 function getLine() {
 	var e = new Error();
 	// now magic will happen: get line number from callstack
-	var line = e.stack.split('\n')[3].split(':')[1];
+	var line = /.*\([^(]*:(\d+):\d+\)$/.exec(e.stack.split('\n')[3])[1];
 	return line;
 }
 

--- a/lib/nlogger.js
+++ b/lib/nlogger.js
@@ -56,7 +56,12 @@ function getDate() {
 function getLine() {
 	var e = new Error();
 	// now magic will happen: get line number from callstack
-	var line = /.*\([^(]*:(\d+):\d+\)$/.exec(e.stack.split('\n')[3])[1];
+	try {
+		var line = /:(\d+):\d+\)?$/.exec(e.stack.split('\n')[3])[1];
+	} catch (ex) {
+		// Preventive fallback in case sh*t gets serious
+		line = -1;
+	}
 	return line;
 }
 


### PR DESCRIPTION
Hello, 

  I've just corrected a bug on the line number routine, when running on windows: the drive letter got in the way, and the routine returned the file path instead of the line number. I got around it by using a regex to extract the line number. Haven't tested it on Linux, but should work okay, too.
