### PR TITLE
Changed require sys to require util...

### DIFF
--- a/lib/nlogger.js
+++ b/lib/nlogger.js
@@ -23,7 +23,7 @@
 	THE SOFTWARE.
 */
 
-var sys = require('sys'),
+var sys = require('util'),
 	fs = require('fs');
 
 


### PR DESCRIPTION
Stops this message:

"The "sys" module is now called "util". It should have a similar interface."

From appearing everytime the package is required
