### PR TITLE
Replaced util.puts with console.log due to deprecation in Node 0.11

### DIFF
--- a/lib/nlogger.js
+++ b/lib/nlogger.js
@@ -92,7 +92,7 @@ try {
 	var file = fs.readFileSync('./nlogger.json', 'binary'),
 		config = JSON.parse(file);
 } catch(e) {
-	util.puts(getDate() + ' WARN  nlogger - Config file not found. Using default configuration.');
+	console.log('%s', getDate() + ' WARN  nlogger - Config file not found. Using default configuration.');
 	config = {};
 }
 
@@ -120,13 +120,13 @@ exports.logger = function(module) {
 		if (useColor) {
 			logger[level] = function(msg) {
 				if (methods[level].priority >= priority) {
-					util.puts('\x1B[' + methods[level].color + 'm' + getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + getMessage(arguments) + '\x1B[0m');
+					console.log('%s', '\x1B[' + methods[level].color + 'm' + getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + getMessage(arguments) + '\x1B[0m');
 				}
 			};
 		} else {
 			logger[level] = function(msg) {
 				if (methods[level].priority >= priority) {
-					util.puts(getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + getMessage(arguments));
+					console.log('%s', getDate() + ' ' + levelStr + ' ' + getClass(module) +':' + getLine() + ' - ' + getMessage(arguments));
 				}
 			};
 		}


### PR DESCRIPTION
Since `util.puts` was deprecated in Node 0.11 every call also outputs:

```
util.puts: Use console.log instead
```

Using `console.log` is the recommended way to output to `stdout`.
