### PR TITLE
Fixed line number extraction on Windows.

### DIFF
--- a/lib/nlogger.js
+++ b/lib/nlogger.js
@@ -56,7 +56,8 @@ function getDate() {
 function getLine() {
 	var e = new Error();
 	// now magic will happen: get line number from callstack
-	var line = e.stack.split('\n')[3].split(':')[1];
+	var elements = e.stack.split('\n')[3].split(':');
+	var line = elements[elements.length - 2];
 	return line;
 }
 


### PR DESCRIPTION
Line number extraction did not work correctly on Windows because the file path also contains a colon.
